### PR TITLE
Join/Leave message delay configuration option

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -117,7 +117,7 @@ public class GriefPrevention extends JavaPlugin
 	public static final int TREE_RADIUS = 5;
 	
 	//how long to wait before deciding a player is staying online or staying offline, for notication messages
-	public static final int NOTIFICATION_SECONDS = 20;
+	public static int NOTIFICATION_SECONDS = 20;
 	
 	//adds a server log entry
 	public static void AddLogEntry(String entry)
@@ -222,6 +222,7 @@ public class GriefPrevention extends JavaPlugin
 		this.config_spam_allowedIpAddresses = config.getString("GriefPrevention.Spam.AllowedIpAddresses", "1.2.3.4; 5.6.7.8");
 		this.config_spam_banOffenders = config.getBoolean("GriefPrevention.Spam.BanOffenders", true);		
 		this.config_spam_banMessage = config.getString("GriefPrevention.Spam.BanMessage", "Banned for spam.");
+		this.NOTIFICATION_SECONDS = config.getInt("GriefPrevention.Spam.JoinLeaveDelay", 20);
 		String slashCommandsToMonitor = config.getString("GriefPrevention.Spam.MonitorSlashCommands", "/me;/tell;/global;/local");
 		
 		this.config_pvp_protectFreshSpawns = config.getBoolean("GriefPrevention.PvP.ProtectFreshSpawns", true);
@@ -338,6 +339,7 @@ public class GriefPrevention extends JavaPlugin
 		config.set("GriefPrevention.Spam.WarningMessage", this.config_spam_warningMessage);
 		config.set("GriefPrevention.Spam.BanOffenders", this.config_spam_banOffenders);		
 		config.set("GriefPrevention.Spam.BanMessage", this.config_spam_banMessage);
+		config.set("GriefPrevention.Spam.JoinLeaveDelay", this.NOTIFICATION_SECONDS);
 		config.set("GriefPrevention.Spam.AllowedIpAddresses", this.config_spam_allowedIpAddresses);
 		
 		config.set("GriefPrevention.PvP.ProtectFreshSpawns", this.config_pvp_protectFreshSpawns);

--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -434,14 +434,18 @@ class PlayerEventHandler implements Listener
 		long elapsed = Calendar.getInstance().getTimeInMillis() - playerData.lastLogout;
 		
 		//remember message, then silence it.  may broadcast it later
-		String message = event.getJoinMessage();
-		event.setJoinMessage(null);
 		
-		if(message != null && elapsed >= GriefPrevention.NOTIFICATION_SECONDS * 1000)
-		{
-			//start a timer for a delayed join notification message (will only show if player is still online in 30 seconds)
-			JoinLeaveAnnouncementTask task = new JoinLeaveAnnouncementTask(event.getPlayer(), message, true);		
-			GriefPrevention.instance.getServer().getScheduler().scheduleSyncDelayedTask(GriefPrevention.instance, task, 20L * GriefPrevention.NOTIFICATION_SECONDS);
+		//only do this if notification_seconds is bigger than 0
+		if(GriefPrevention.NOTIFICATION_SECONDS > 0) {
+			String message = event.getJoinMessage();
+			event.setJoinMessage(null);
+			
+			if(message != null && elapsed >= GriefPrevention.NOTIFICATION_SECONDS * 1000)
+			{
+				//start a timer for a delayed join notification message (will only show if player is still online in 30 seconds)
+				JoinLeaveAnnouncementTask task = new JoinLeaveAnnouncementTask(event.getPlayer(), message, true);		
+				GriefPrevention.instance.getServer().getScheduler().scheduleSyncDelayedTask(GriefPrevention.instance, task, 20L * GriefPrevention.NOTIFICATION_SECONDS);
+			}
 		}
 	}
 	
@@ -465,7 +469,11 @@ class PlayerEventHandler implements Listener
 		this.onPlayerDisconnect(event.getPlayer(), event.getQuitMessage());
 		
 		//silence the leave message (may be broadcast later, if the player stays offline)
-		event.setQuitMessage(null);
+		
+		//only do this if notification_seconds is bigger than 0
+		if(GriefPrevention.NOTIFICATION_SECONDS > 0) {
+			event.setQuitMessage(null);			
+		}
 	}
 	
 	//helper for above
@@ -496,11 +504,15 @@ class PlayerEventHandler implements Listener
 		playerData.lastLogout = Calendar.getInstance().getTimeInMillis();
 		
 		//if notification message isn't null and the player has been online for at least 30 seconds...
-		if(notificationMessage != null && elapsed >= 1000 * GriefPrevention.NOTIFICATION_SECONDS)
-		{
-			//start a timer for a delayed leave notification message (will only show if player is still offline in 30 seconds)
-			JoinLeaveAnnouncementTask task = new JoinLeaveAnnouncementTask(player, notificationMessage, false);		
-			GriefPrevention.instance.getServer().getScheduler().scheduleSyncDelayedTask(GriefPrevention.instance, task, 20L * GriefPrevention.NOTIFICATION_SECONDS);		
+		
+		//only do this if notification_seconds is bigger than 0
+		if(GriefPrevention.NOTIFICATION_SECONDS > 0) {
+			if(notificationMessage != null && elapsed >= 1000 * GriefPrevention.NOTIFICATION_SECONDS)
+			{
+				//start a timer for a delayed leave notification message (will only show if player is still offline in 30 seconds)
+				JoinLeaveAnnouncementTask task = new JoinLeaveAnnouncementTask(player, notificationMessage, false);		
+				GriefPrevention.instance.getServer().getScheduler().scheduleSyncDelayedTask(GriefPrevention.instance, task, 20L * GriefPrevention.NOTIFICATION_SECONDS);		
+			}
 		}
 	}
 


### PR DESCRIPTION
I happen to own a plugin that customizes the join/leave messages and this plugin seems to conflict with them.  Since I'm not a huge fan of this delay, i've decided to help you by making it a configuration option.

Would you mind consider adding it to GriefPrevention so it works with my plugins too?  This is so I don't have to recompile GriefPrevention with these changes every single update.  I love your plugin and all, but 4.3 caused a few problems and I'd like to resolve it with this new delay being a configurable option.
