### PR TITLE
API: Ability to access list of claims and locations of both points in a claim

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/me/ryanhamshire/GriefPrevention/Claim.java
@@ -39,8 +39,8 @@ public class Claim
 {
 	//two locations, which together define the boundaries of the claim
 	//note that the upper Y value is always ignored, because claims ALWAYS extend up to the sky
-	Location lesserBoundaryCorner;
-	Location greaterBoundaryCorner;
+	public Location lesserBoundaryCorner;
+	public Location greaterBoundaryCorner;
 	
 	//modification date.  this comes from the file timestamp during load, and is updated with runtime changes
 	public Date modifiedDate;

--- a/src/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -38,7 +38,7 @@ public abstract class DataStore
 	protected ConcurrentHashMap<String, Integer> permissionToBonusBlocksMap = new ConcurrentHashMap<String, Integer>();
 	
 	//in-memory cache for claim data
-	ArrayList<Claim> claims = new ArrayList<Claim>();
+	public ArrayList<Claim> claims = new ArrayList<Claim>();
 	
 	//in-memory cache for messages
 	private String [] messages;


### PR DESCRIPTION
It would be useful if those two things would be in API for other plugins to access. 

If you are afraid of other plugins messing this up, make public functions instead that would return clone of those variables.
