### PR TITLE
Don't allow claiming if event is cancelled

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2061,6 +2061,9 @@ class PlayerEventHandler implements Listener
 				return;
 			}
 			
+			//if event is cancelled, don't do anything
+			if(event.isCancelled) return;
+			
 			//if the player doesn't have claims permission, don't do anything
 			if(!player.hasPermission("griefprevention.createclaims"))
 			{


### PR DESCRIPTION
Added event.isCancelled to allow other plugins to deny the creation/expanding of claims.