### PR TITLE
Allow water to be selected from long distance

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2654,7 +2654,6 @@ class PlayerEventHandler implements Listener
 	    {
 	        result = iterator.next();
 	        if(result.getType() != Material.AIR && 
-	           result.getType() != Material.STATIONARY_WATER &&
 	           result.getType() != Material.LONG_GRASS) return result;
 	    }
 	    


### PR DESCRIPTION
I'm not entirely sure why stationary_water is excluded from checking what block is selected from long distance - and a highly doubt players manage claims while under water. This should also make it a lot easier to create and alter claims which have corners over water. (Also see https://www.spigotmc.org/threads/griefprevention.35615/page-67#post-1123457 )