### PR TITLE
Make /deleteclaim also restore claims in survival worlds if configured to do so

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1560,8 +1560,8 @@ public class GriefPrevention extends JavaPlugin
 						claim.removeSurfaceFluids(null);
 						this.dataStore.deleteClaim(claim, true);
 						
-						//if in a creative mode world, /restorenature the claim
-						if(GriefPrevention.instance.creativeRulesApply(claim.getLesserBoundaryCorner()))
+						//if in a creative mode world or if survival claims are configured to be restored, /restorenature the claim
+						if(GriefPrevention.instance.creativeRulesApply(claim.getLesserBoundaryCorner()) || GriefPrevention.instance.config_claims_survivalAutoNatureRestoration)
 						{
 							GriefPrevention.instance.restoreClaim(claim, 0);
 						}


### PR DESCRIPTION
So it can match https://github.com/ryanhamshire/GriefPrevention/search?utf8=%E2%9C%93&q=config_claims_survivalAutoNatureRestoration&type=Code