### PR TITLE
Don't give chorus fruit if teleport was canceled

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1152,8 +1152,6 @@ class PlayerEventHandler implements Listener
 					event.setCancelled(true);
 					if(cause == TeleportCause.ENDER_PEARL)
 					    player.getInventory().addItem(new ItemStack(Material.ENDER_PEARL));
-					else
-					    player.getInventory().addItem(new ItemStack(Material.CHORUS_FRUIT));
 				}
 			}
 		}


### PR DESCRIPTION
https://www.spigotmc.org/threads/griefprevention.35615/page-115#post-1452430

> you never lose your chorus fruit in other's claim. so you need only 1 chorus fruit. you will never be hungry.

---

Not sure if you want to either have the chorus fruit consumed or to block the eating action altogether (making a player unable to replenish hunger while inside a claim they don't have accesstrust). 