### PR TITLE
Make IgnoreMode enum public

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -2636,7 +2636,7 @@ public class GriefPrevention extends JavaPlugin
         }
 	}
 	
-	enum IgnoreMode	{None, StandardIgnore, AdminIgnore}
+	public enum IgnoreMode	{None, StandardIgnore, AdminIgnore}
 	
 	private String trustEntryToPlayerName(String entry)
 	{


### PR DESCRIPTION
I'd like to be able to know if an admin separated a player or not.