### PR TITLE
Don't check new players in deletion task

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/CleanupUnusedClaimPreTask.java
+++ b/src/me/ryanhamshire/GriefPrevention/CleanupUnusedClaimPreTask.java
@@ -39,6 +39,9 @@ class CleanupUnusedClaimPreTask implements Runnable
 		//get the data
 	    PlayerData ownerData = GriefPrevention.instance.dataStore.getPlayerDataFromStorage(claim.ownerID);
 	    OfflinePlayer ownerInfo = Bukkit.getServer().getOfflinePlayer(claim.ownerID);
+	    //If server believes owner is new to player, it won't have a proper getLastPlayed date to check.
+	    if (ownerInfo.hasPlayedBefore())
+	        return;
 	    
 	    GriefPrevention.AddLogEntry("Looking for expired claims.  Checking data for " + claim.ownerID.toString(), CustomLogEntryTypes.Debug, true);
 	    


### PR DESCRIPTION
Otherwise they will have an improper getLastPlayed date, which results in new players losing their claims within minutes.