### PR TITLE
allow /separate and /unseparate to be used in console

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -2624,7 +2624,7 @@ public class GriefPrevention extends JavaPlugin
         }
 		
 		//separateplayers
-        else if(cmd.getName().equalsIgnoreCase("separate") && player != null)
+        else if(cmd.getName().equalsIgnoreCase("separate"))
         {
             //requires two player names
             if(args.length < 2) return false;
@@ -2652,7 +2652,7 @@ public class GriefPrevention extends JavaPlugin
         }
 		
 		//unseparateplayers
-        else if(cmd.getName().equalsIgnoreCase("unseparate") && player != null)
+        else if(cmd.getName().equalsIgnoreCase("unseparate"))
         {
             //requires two player names
             if(args.length < 2) return false;


### PR DESCRIPTION
Afaik, player (sender) object isn't used in either of these methods.