### PR TITLE
Check player is allowed to resize a claim

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1175,6 +1175,15 @@ public abstract class DataStore
 	//see CreateClaim() for details on return value
 	synchronized public CreateClaimResult resizeClaim(Claim claim, int newx1, int newx2, int newy1, int newy2, int newz1, int newz2, Player resizingPlayer)
 	{
+                // Before checking overlaps etc, check the player is in fact
+                // able to resize this claim
+                String cantResizeMessage = claim.allowEdit(resizingPlayer);
+                if (cantResizeMessage != null) {
+                    GriefPrevention.sendMessage(resizingPlayer, TextMode.Err, cantResizeMessage);
+                    CreateClaimResult fail = null;
+                    return fail;
+                }
+
 		//try to create this new claim, ignoring the original when checking for overlap
 		CreateClaimResult result = this.createClaim(claim.getLesserBoundaryCorner().getWorld(), newx1, newx2, newy1, newy2, newz1, newz2, claim.ownerID, claim.parent, claim.id, resizingPlayer);
 		
@@ -1221,12 +1230,6 @@ public abstract class DataStore
 	
 	void resizeClaimWithChecks(Player player, PlayerData playerData, int newx1, int newx2, int newy1, int newy2, int newz1, int newz2)
     {
-        // First, make sure the player is allowed to resize the claim:
-        String cantResizeMessage = playerData.claimResizing.allowEdit(player);
-        if (cantResizeMessage != null) {
-            GriefPrevention.sendMessage(player, TextMode.Err, cantResizeMessage);
-            return;
-        }
 	//for top level claims, apply size rules and claim blocks requirement
         if(playerData.claimResizing.parent == null)
         {               

--- a/src/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1221,7 +1221,13 @@ public abstract class DataStore
 	
 	void resizeClaimWithChecks(Player player, PlayerData playerData, int newx1, int newx2, int newy1, int newy2, int newz1, int newz2)
     {
-	    //for top level claims, apply size rules and claim blocks requirement
+        // First, make sure the player is allowed to resize the claim:
+        String cantResizeMessage = playerData.claimResizing.allowEdit(player);
+        if (cantResizeMessage != null) {
+            GriefPrevention.sendMessage(player, TextMode.Err, cantResizeMessage);
+            return;
+        }
+	//for top level claims, apply size rules and claim blocks requirement
         if(playerData.claimResizing.parent == null)
         {               
             //measure new claim, apply size rules

--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1692,7 +1692,7 @@ public class GriefPrevention extends JavaPlugin
 			//if no parameter, just tell player cost per block and balance
 			if(args.length != 1)
 			{
-				GriefPrevention.sendMessage(player, TextMode.Info, Messages.BlockPurchaseCost, String.valueOf(GriefPrevention.instance.config_economy_claimBlocksPurchaseCost), String.valueOf(GriefPrevention.economy.getBalance(player)));
+				GriefPrevention.sendMessage(player, TextMode.Info, Messages.BlockPurchaseCost, String.valueOf(GriefPrevention.instance.config_economy_claimBlocksPurchaseCost), String.valueOf(GriefPrevention.economy.getBalance(player.getName())));
 				return false;
 			}
 			
@@ -1717,7 +1717,7 @@ public class GriefPrevention extends JavaPlugin
 				}
 				
 				//if the player can't afford his purchase, send error message
-				double balance = economy.getBalance(player);				
+				double balance = economy.getBalance(player.getName());				
 				double totalCost = blockCount * GriefPrevention.instance.config_economy_claimBlocksPurchaseCost;				
 				if(totalCost > balance)
 				{
@@ -1728,7 +1728,7 @@ public class GriefPrevention extends JavaPlugin
 				else
 				{
 					//withdraw cost
-					economy.withdrawPlayer(player, totalCost);
+					economy.withdrawPlayer(player.getName(), totalCost);
 					
 					//add blocks
 					playerData.setBonusClaimBlocks(playerData.getBonusClaimBlocks() + blockCount);
@@ -1803,7 +1803,7 @@ public class GriefPrevention extends JavaPlugin
 			{					
 				//compute value and deposit it
 				double totalValue = blockCount * GriefPrevention.instance.config_economy_claimBlocksSellValue;					
-				economy.depositPlayer(player, totalValue);
+				economy.depositPlayer(player.getName(), totalValue);
 				
 				//subtract blocks
 				playerData.setBonusClaimBlocks(playerData.getBonusClaimBlocks() - blockCount);


### PR DESCRIPTION
Ensure that players cannot resize other player's claims.

This issue reported by Print_USMC at https://www.spigotmc.org/threads/griefprevention.35615/page-137#post-1690189 - I've been able to reproduce it myself, and can confirm that this fix does indeed stop it for me.

I'm not entirely happy with this fix, though, as when an attempt to resize another player's claim fails, you get the "cannot create a claim here as it would overlap..." message, not the Messages.OnlyOwnersModifyClaims message I'd have expected - and I don't see why that is.